### PR TITLE
Allow other columns for status

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ $user = User::whereRaw('status = ' . User::getStatusCode('suspended'))->first();
 $user->status == 'suspended' // true
 ```
 
+To use a custom field in your model for status, add the `$statusFieldName` Property to the model. Example:
+```php
+class User {
+    protected $statusFieldName = 'sent_status';
+}
+```
+
 Getting all the defined statuses for a given model is also easy as the snippet below. We get all the defined statuses for the `User` model and display them in a select element:
 
 ```php

--- a/src/Traits/LastusTrait.php
+++ b/src/Traits/LastusTrait.php
@@ -23,7 +23,7 @@ trait LastusTrait
     /**
      * Set status field name
      *
-     * @param [type] $fieldName
+     * @param string $fieldName
      * @return void
      */
     public function setStatusFieldName($fieldName) {

--- a/src/Traits/LastusTrait.php
+++ b/src/Traits/LastusTrait.php
@@ -6,6 +6,30 @@ use Nzesalem\Lastus\Lastus;
 
 trait LastusTrait
 {
+    protected function getStatusFieldName() {
+        return isset($this->statusFieldName) ? $this->statusFieldName : 'status';
+    }
+
+    public function setStatusFieldName($fieldName) {
+        $this->userStatusFieldName = $fieldName;
+    }
+
+    /**
+     * Dynamically retrieve attributes on the model.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        if ($key === $this->getStatusFieldName()) {
+            $value = $this->getOriginal($key, 1);
+            return $this->getLastusStatus($value);
+        }
+
+        return parent::__get($key);
+    }
+
     /**
      * Status accessor
      *
@@ -14,11 +38,12 @@ trait LastusTrait
      *
      * @throws \InvalidArgumentException
      */
-    public function getStatusAttribute($value)
+    public function getLastusStatus($value)
     {
         if (! is_numeric($value)) {
             throw new \InvalidArgumentException('Model status should be stored as an integer');
         }
+
         return Lastus::statusName(static::class, $value);
     }
 

--- a/src/Traits/LastusTrait.php
+++ b/src/Traits/LastusTrait.php
@@ -7,6 +7,11 @@ use Nzesalem\Lastus\Lastus;
 
 trait LastusTrait
 {
+    /**
+     * Return the status field name set in Model or return status (by default)
+     *
+     * @return string
+     */
     protected function getStatusFieldName() {
         try {
             return $this->statusFieldName;
@@ -15,6 +20,12 @@ trait LastusTrait
         }
     }
 
+    /**
+     * Set status field name
+     *
+     * @param [type] $fieldName
+     * @return void
+     */
     public function setStatusFieldName($fieldName) {
         $this->statusFieldName = $fieldName;
     }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -15,6 +15,7 @@ use Nzesalem\Lastus\Tests\Models\Email;
  */
 class BaseTest extends TestCase
 {
+    protected $statusFieldName = 'status';
     /**
      * Test basic Lastus functionality.
      */
@@ -36,7 +37,27 @@ class BaseTest extends TestCase
      */
     public function testMutatorAndAccessorWithCustomStatusField()
     {
-        $user = User::create([
+        $user = new User();
+        $user->setStatusFieldName('email');
+
+        $user->fill([
+            'name' => 'Salem Nzeukwu',
+            'email' => 'blocked',
+            'password' => bcrypt('secret'),
+            'custom_status' => 'blocked',
+        ]);
+        
+        $user->save();
+        
+        $this->assertEquals('blocked', $user->email);
+    }
+
+    /**
+     * Test basic Lastus functionality.
+     */
+    public function testUpdateWithCustomStatusField()
+    {
+        $user = new User([
             'name' => 'Salem Nzeukwu',
             'email' => 'blocked',
             'password' => bcrypt('secret'),
@@ -44,8 +65,12 @@ class BaseTest extends TestCase
         ]);
 
         $user->setStatusFieldName('email');
+        $user->save();
+
+        $user->email = 'active';
         
-        $this->assertEquals('blocked', $user->email);
+        $this->assertEquals('active', $user->email);
+        $this->assertEquals(1, $user->getAttributes()['email']);
     }
 
     public function testModelStatusCodeMethod()

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Nzesalem\Lastus\Lastus;
 use Illuminate\Support\Facades\DB;
 use Nzesalem\Lastus\Tests\Models\User;
+use Nzesalem\Lastus\Tests\Models\Email;
 
 /**
  * Class BaseTest
@@ -28,6 +29,23 @@ class BaseTest extends TestCase
         ]);
         
         $this->assertEquals('active', $user->status);
+    }
+
+    /**
+     * Test basic Lastus functionality.
+     */
+    public function testMutatorAndAccessorWithCustomStatusField()
+    {
+        $user = User::create([
+            'name' => 'Salem Nzeukwu',
+            'email' => 'blocked',
+            'password' => bcrypt('secret'),
+            'custom_status' => 'blocked',
+        ]);
+
+        $user->setStatusFieldName('email');
+        
+        $this->assertEquals('blocked', $user->email);
     }
 
     public function testModelStatusCodeMethod()

--- a/tests/Models/Email.php
+++ b/tests/Models/Email.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Nzesalem\Lastus\Tests\Models;
+
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Nzesalem\Lastus\Traits\LastusTrait;
+
+class Email extends Authenticatable
+{
+    use Notifiable, LastusTrait;
+
+    /**
+     * Define statuses
+     */
+    const STATUSES = [
+        'FAILED' => 0,
+        'PENDING' => 1,
+        'SENT' => 2,
+        'BLOCKED' => 3,
+    ];
+
+    public $statusFieldName = 'send_status';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name', 'email', 'password', 'status',
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'password', 'remember_token',
+    ];
+}

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -37,4 +37,6 @@ class User extends Authenticatable
     protected $hidden = [
         'password', 'remember_token',
     ];
+
+    protected $statusFieldName = 'status';
 }


### PR DESCRIPTION
Addresses this issue: [How can I use a different name for the status attribute?](https://github.com/nzesalem/lastus/issues/2) which seems to be a duplicate of: [How to change the name for the users table?](https://github.com/nzesalem/lastus/issues/3)