### PR TITLE
php 8 and doctrine/dbal 3.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.2.0|^8.0",
         "illuminate/support": "^8.0",
-        "doctrine/dbal": "^2.11"
+        "doctrine/dbal": "^2.11|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",


### PR DESCRIPTION
```cli
*** lastus % phpunit tests/BaseTest.php 
PHPUnit 9.5.2 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.16
Configuration: /***/Packages/lastus/phpunit.xml
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...                                                                 3 / 3 (100%)

Time: 00:00.404, Memory: 38.50 MB

OK (3 tests, 3 assertions)
```

```cli
*** lastus % php@8 ./vendor/bin/phpunit tests/BaseTest.php 
PHPUnit 9.5.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.3
Configuration: /***/Packages/lastus/phpunit.xml
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...                                                                 3 / 3 (100%)

Time: 00:00.414, Memory: 24.00 MB

OK (3 tests, 3 assertions)
```